### PR TITLE
Added secret and removalPolicy

### DIFF
--- a/bin/serverless_blog.ts
+++ b/bin/serverless_blog.ts
@@ -25,9 +25,7 @@ const app = new cdk.App();
     accountIdParameter: "/serverlessBlog/accountId",
     domainNameParameter: "/serverlessBlog/domainName",
     googleOAuthClientIdParameter: "/serverlessBlog/googleOAuthClientId",
-    // googleOAuthClientSecret has not yet been implemented because I'm cheap and don't want to pay $.40 USD/month/secret.
-    // It will be implemented when I figure out all the other secrets I need to store so I can make the most of the 30 day free trial.
-    googleOAuthClientSecret: "PLACEHOLDER", 
+    cognitoUserPoolRetentionOnStackDestroy: cdk.RemovalPolicy.DESTROY
   });
   
   cdk.Tags.of(app).add("Project", project);

--- a/lib/cognito_stack.ts
+++ b/lib/cognito_stack.ts
@@ -15,7 +15,7 @@ export interface CognitoStackProps extends cdk.StackProps {
   readonly accountIdParameter: string;
   readonly domainNameParameter: string;
   readonly googleOAuthClientIdParameter: string;
-  readonly googleOAuthClientSecret: string;
+  readonly cognitoUserPoolRetentionOnStackDestroy: cdk.RemovalPolicy;
 }
 
 export class CognitoStack extends Construct {
@@ -41,11 +41,10 @@ export class CognitoStack extends Construct {
         props.googleOAuthClientIdParameter
       );
 
-    const googleOAuthClientSecret = aws_secretsmanager.Secret.fromSecretNameV2(
-      this,
-      "SecretName",
-      props.googleOAuthClientSecret
-    );
+    const googleOAuthClientSecret = new aws_secretsmanager.Secret(this, "googleOAuthClientSecret", {
+      secretName: "googleOAuthClientSecret",
+      description: "The client secret generated in the Google API console",
+    })
     // User Auth
     // Cognito User Pool
     const cognitoUserPool = new aws_cognito.UserPool(this, "blogUserPool", {
@@ -96,6 +95,7 @@ export class CognitoStack extends Construct {
         // Sends a link the user can follow to verify their account
         emailStyle: aws_cognito.VerificationEmailStyle.LINK,
       },
+      removalPolicy: props.cognitoUserPoolRetentionOnStackDestroy
     });
 
     // Setup google to be an Authentication provider for Cognito and add it to the above userPool

--- a/lib/serverless_blog-stack.ts
+++ b/lib/serverless_blog-stack.ts
@@ -16,7 +16,7 @@ export interface ServerlessBlogStackProps extends cdk.StackProps {
   readonly accountIdParameter: string;
   readonly domainNameParameter: string;
   readonly googleOAuthClientIdParameter: string;
-  readonly googleOAuthClientSecret: string;
+  readonly cognitoUserPoolRetentionOnStackDestroy: cdk.RemovalPolicy;
 }
 
 export class ServerlessBlogStack extends cdk.Stack {
@@ -51,9 +51,7 @@ export class ServerlessBlogStack extends cdk.Stack {
       accountIdParameter: props.accountIdParameter,
       domainNameParameter: props.domainNameParameter,
       googleOAuthClientIdParameter: props.googleOAuthClientIdParameter,
-      // googleOAuthClientSecret has not yet been implemented because I'm cheap and don't want to pay $.40 USD/month/secret.
-      // It will be implemented when I figure out all the other secrets I need to store so I can make the most of the 30 day free trial.
-      googleOAuthClientSecret: props.googleOAuthClientSecret,
+      cognitoUserPoolRetentionOnStackDestroy: props.cognitoUserPoolRetentionOnStackDestroy
     });
 
     new DynamoDBStack(this, "DynamoDBStack", {


### PR DESCRIPTION
Create the Google Auth client secret in the stack and update its value in the console (This may need to be changed to be a manually created secret, add value and import into stack at creation depending on if it needs a value at deploy). Added a removalPolicy prop for the cognito userPool as it is retained on stack destruction by default. The stack deploys in this current state.